### PR TITLE
Resolve strict comparison issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const CRLF = '\r\n'
 const LF = '\n'
 
 function stringifyPackage (data, indent, newline) {
-  const json = JSON.stringify(data, null, indent || DEFAULT_INDENT)
+  indent = indent || (indent === 0 ? 0 : DEFAULT_INDENT)
+  const json = JSON.stringify(data, null, indent)
 
   if (newline === CRLF) {
     return json.replace(/\n/g, CRLF) + CRLF

--- a/test/nonformatted.js
+++ b/test/nonformatted.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const stringifyPackage = require('../index')
+const test = require('tap').test
+
+const dummy = { name: 'dummy' }
+
+test('stringify-package', function (t) {
+  t.equal(stringifyPackage(dummy, 0).split(/\r\n|\r|\n/).length, 2, '0 works')
+  t.end()
+})


### PR DESCRIPTION
Currently `stringify-package` does not allow to use 0 as indent value.